### PR TITLE
fix: changing github workflow file to post comment on PR open

### DIFF
--- a/.github/workflows/terraform-deploy-aws.yml
+++ b/.github/workflows/terraform-deploy-aws.yml
@@ -10,7 +10,7 @@ on:
     paths:
     - 'AWS/**'
     - '!AWS/**.md'
-  pull_request_target:
+  pull_request:
     branches:
       - main
     paths:
@@ -100,9 +100,9 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           INFRACOST_TERRAFORM_CLOUD_TOKEN: ${{ secrets.TF_API_TOKEN }}
         with:
-          entrypoint: /scripts/ci/diff.sh # Do not change
           path: ${{ env.TFPath }}
           show_skipped: true
+          post_condition: '{"update": true}'
 
       - name: "Infracost output"
         run: echo '${{ steps.cost.outputs.total_monthly_cost }}'

--- a/.github/workflows/terraform-deploy-azure.yml
+++ b/.github/workflows/terraform-deploy-azure.yml
@@ -10,7 +10,7 @@ on:
     paths:
     - 'Azure/**'
     - '!Azure/**.md'
-  pull_request_target:
+  pull_request:
     branches:
       - main
     paths:
@@ -101,9 +101,9 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           INFRACOST_TERRAFORM_CLOUD_TOKEN: ${{ secrets.TF_API_TOKEN }}
         with:
-          entrypoint: /scripts/ci/diff.sh # Do not change
           path: ${{ env.TFPath }}
           show_skipped: true
+          post_condition: '{"update": true}'
 
       - name: "Infracost output"
         run: echo '${{ steps.cost.outputs.total_monthly_cost }}'


### PR DESCRIPTION
fixes issues where the `infracost diff` was not posting output to the PR but to the comment. This was due to `pull_request_target` being used over `pull_request`. The infracost legacy `diff.sh` uses `pull_request` event name to determine whether to publish to commit or PR - so have changed to use the latter. We now have more up to date "composable" actions which can be found here: https://github.com/infracost/actions which would allow you to have a more flexible approach if needed. Reach out to me/the team on slack if you need any help migrating to these.

Hope this helps.